### PR TITLE
Fix semver tag push with proper refspec handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,11 +121,11 @@ jobs:
           git fetch origin "+refs/tags/*:refs/tags/*" --force
 
           if ($env:MAJOR_TAG -and $env:MAJOR_TAG -ne $env:RELEASE_TAG) {
-            git tag -f $env:MAJOR_TAG $env:RELEASE_TAG
-            git push --force origin "refs/tags/$env:MAJOR_TAG"
+            $refspec = "refs/tags/${env:RELEASE_TAG}:refs/tags/${env:MAJOR_TAG}"
+            git push --force origin $refspec
           }
 
           if ($env:MINOR_TAG -and $env:MINOR_TAG -ne $env:RELEASE_TAG) {
-            git tag -f $env:MINOR_TAG $env:RELEASE_TAG
-            git push --force origin "refs/tags/$env:MINOR_TAG"
+            $refspec = "refs/tags/${env:RELEASE_TAG}:refs/tags/${env:MINOR_TAG}"
+            git push --force origin $refspec
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,12 +116,16 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git fetch --tags --force
+          
+          # Fetch all tags from remote to ensure we have the release tag created by gh-extension-precompile
+          git fetch origin "+refs/tags/*:refs/tags/*" --force
 
           if ($env:MAJOR_TAG -and $env:MAJOR_TAG -ne $env:RELEASE_TAG) {
-            git push --force origin ("refs/tags/{0}:refs/tags/{1}" -f $env:RELEASE_TAG, $env:MAJOR_TAG)
+            git tag -f $env:MAJOR_TAG $env:RELEASE_TAG
+            git push --force origin "refs/tags/$env:MAJOR_TAG"
           }
 
           if ($env:MINOR_TAG -and $env:MINOR_TAG -ne $env:RELEASE_TAG) {
-            git push --force origin ("refs/tags/{0}:refs/tags/{1}" -f $env:RELEASE_TAG, $env:MINOR_TAG)
+            git tag -f $env:MINOR_TAG $env:RELEASE_TAG
+            git push --force origin "refs/tags/$env:MINOR_TAG"
           }


### PR DESCRIPTION
## Summary
Fix semver tag push issues that were not included in PR #5.

## Changes

### 1. Fix tag reference error (63a178f)
- Fetch all tags from remote before attempting to push derived tags
- Create local tags from the release tag before pushing
- Ensures the release tag created by gh-extension-precompile is available locally

### 2. Use refspec variable for PowerShell compatibility (500c594)
- Construct refspec string in a variable before git push
- Avoids PowerShell issues with colon (:) in inline strings
- Follows the pattern from conflict-resolver repository

## Problem
The previous PR #5 only included the draft_release fix but missed these two critical commits for proper semver tag handling.

## Testing
- Local: `go test ./...` ✅
- Will validate in workflow execution after merge