### PR TITLE
Fix git fetch command to use correct refspec syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           
           # Fetch all tags from remote to ensure we have the release tag created by gh-extension-precompile
-          git fetch --tags --force origin
+          git fetch origin "+refs/tags/*:refs/tags/*" --force
 
           if ($env:MAJOR_TAG -and $env:MAJOR_TAG -ne $env:RELEASE_TAG) {
             $refspec = "refs/tags/${env:RELEASE_TAG}:refs/tags/${env:MAJOR_TAG}"


### PR DESCRIPTION
## Summary
Fix the git fetch command that was incorrectly changed from the correct refspec syntax.

## Problem
The git fetch command was changed from:
```pwsh
git fetch origin "+refs/tags/*:refs/tags/*" --force
```

to:
```pwsh
git fetch --tags --force origin
```

This incorrect syntax caused the error:
```
error: src refspec refs/tags/v0.1.1 does not match any
error: failed to push some refs to 'https://github.com/VeyronSakai/gh-runner-monitor'
```

## Solution
Revert to the correct refspec syntax that properly fetches all remote tags to local tags.

## References
- Error log: https://github.com/VeyronSakai/gh-runner-monitor/actions/runs/18283126342/job/52050930677
- Original fix in PR #6: commits 65cd7cc and 338b6fb