### PR TITLE
Fix semver tag creation by creating tags locally

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,12 +120,20 @@ jobs:
           # Fetch all tags from remote to ensure we have the release tag created by gh-extension-precompile
           git fetch origin "+refs/tags/*:refs/tags/*" --force
 
-          if ($env:MAJOR_TAG -and $env:MAJOR_TAG -ne $env:RELEASE_TAG) {
-            $refspec = "refs/tags/${env:RELEASE_TAG}:refs/tags/${env:MAJOR_TAG}"
-            git push --force origin $refspec
+          # Verify the release tag exists locally
+          if (-not (git rev-parse "refs/tags/$env:RELEASE_TAG" 2>$null)) {
+            Write-Error "Release tag '$env:RELEASE_TAG' not found after fetch."
+            exit 1
           }
 
+          # Create and push major version tag
+          if ($env:MAJOR_TAG -and $env:MAJOR_TAG -ne $env:RELEASE_TAG) {
+            git tag -f $env:MAJOR_TAG $env:RELEASE_TAG
+            git push --force origin "refs/tags/${env:MAJOR_TAG}"
+          }
+
+          # Create and push minor version tag
           if ($env:MINOR_TAG -and $env:MINOR_TAG -ne $env:RELEASE_TAG) {
-            $refspec = "refs/tags/${env:RELEASE_TAG}:refs/tags/${env:MINOR_TAG}"
-            git push --force origin $refspec
+            git tag -f $env:MINOR_TAG $env:RELEASE_TAG
+            git push --force origin "refs/tags/${env:MINOR_TAG}"
           }


### PR DESCRIPTION
## Summary
Create semver tags locally before pushing, instead of using refspec to copy remote tags.

## Problem
The previous approach used refspec to copy remote tags:
```pwsh
$refspec = "refs/tags/${env:RELEASE_TAG}:refs/tags/${env:MAJOR_TAG}"
git push --force origin $refspec
```

This failed with:
```
error: src refspec refs/tags/v0.1.1 does not match any
```

The issue was that `RELEASE_TAG` (v0.1.1) wasn't reliably available locally after `git fetch`, even though it existed on the remote.

## Solution
1. Verify the release tag exists after fetch
2. Create semver tags locally from the release tag: `git tag -f $env:MAJOR_TAG $env:RELEASE_TAG`
3. Push the newly created local tags: `git push --force origin "refs/tags/${env:MAJOR_TAG}"`

This approach is more reliable because:
- We explicitly verify the source tag exists
- We create tags locally before pushing (no dependency on refspec copying)
- Clearer and more maintainable code

## Changes
- Added validation step to verify `RELEASE_TAG` exists after fetch
- Changed from refspec-based tag copying to local tag creation
- Added comments to clarify the process

## Testing
- Will validate in workflow execution after merge

## References
- Error log: https://github.com/VeyronSakai/gh-runner-monitor/actions/runs/18283126342/job/52050930677
- Previous PR #7 (partial fix)