### PR TITLE
Remove publish step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,11 +39,10 @@ jobs:
     env:
       VERSION: ${{ needs.update_release_draft.outputs.tag_name }}
     steps:
-      - name: Publish draft release
+      - name: Get draft release info
         uses: release-drafter/release-drafter@v6
         id: release-drafter
         with:
-          publish: true
           commitish: main
 
       - name: Validate release tag output


### PR DESCRIPTION
The release workflow no longer publishes the draft release directly. The 'publish' input was removed from the release-drafter step, likely to separate drafting and publishing actions.