### PR TITLE
Add permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'workflow_dispatch'
     needs: update_release_draft
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
     env:
       VERSION: ${{ needs.update_release_draft.outputs.tag_name }}
     steps:


### PR DESCRIPTION
Explicitly sets 'contents', 'attestations', and 'id-token' write permissions for the release job in the GitHub Actions workflow to ensure required access for publishing and security operations.