### PR TITLE
feat: Show loading spinner during data fetch

### DIFF
--- a/internal/presentation/view.go
+++ b/internal/presentation/view.go
@@ -20,6 +20,11 @@ func (m *Model) View() string {
 	} else {
 		header = fmt.Sprintf("GitHub Runners Monitor - Repository: %s/%s\n", m.owner, m.repo)
 	}
+
+	if m.loading {
+		return header + fmt.Sprintf("\n%s Loading...\n", m.spinner.View())
+	}
+
 	header += fmt.Sprintf("Last Updated: %s | Press 'q' to quit, 'r' to refresh, 'enter' to open job log\n\n",
 		m.lastUpdate.Format("15:04:05"))
 


### PR DESCRIPTION
## Summary
Display a loading spinner animation while fetching data.

## Changes
- Show spinner animation during initial data fetch
- Show spinner when refreshing with `r` key
- Switch to table view after data fetch completes

## Technical Details
Uses Bubble Tea's `bubbles/spinner` component with a `loading` flag to toggle between spinner and table display.